### PR TITLE
Move the main class location

### DIFF
--- a/src/main/java/baubles/Baubles.java
+++ b/src/main/java/baubles/Baubles.java
@@ -1,4 +1,4 @@
-package baubles.common;
+package baubles;
 
 import baubles.api.BaublesWrapper;
 import baubles.api.IBauble;
@@ -6,6 +6,8 @@ import baubles.api.cap.BaublesCapabilities.CapabilityBaubles;
 import baubles.api.cap.BaublesCapabilities.CapabilityItemBaubleStorage;
 import baubles.api.cap.BaublesContainer;
 import baubles.api.cap.IBaublesModifiable;
+import baubles.common.CommonProxy;
+import baubles.common.Config;
 import baubles.common.network.PacketHandler;
 import baubles.common.util.BaublesRegistry;
 import baubles.common.util.command.CommandBaubles;


### PR DESCRIPTION
Move the main class location. Some mods check the main class's location to set up a blacklisted GUI path, which requires the main class to be outside the GUI package.